### PR TITLE
Added an optional tag argument to count-consul-services

### DIFF
--- a/templates/count-consul-services.erb
+++ b/templates/count-consul-services.erb
@@ -3,7 +3,7 @@ CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 
 display_usage() {
     echo "Count the number of active services registered with consul."
-    echo -e "\nUsage:\n$0 <service-name> \n"
+    echo -e "\nUsage:\n$0 <service-name> [<tag-name>]\n"
 }
 
 if [  $# -lt 1 ]
@@ -12,4 +12,10 @@ then
     exit 1
 fi
 
-$CONSUL watch -type=service -service="$1" -passingonly=true | grep -c '"ID": "'$1'"'
+if [ -n "$2" ]; then
+  TAGOPT=-tag=$2
+else
+  TAGOPT=""
+fi
+
+$CONSUL watch -type=service -service="$1" -passingonly=true $TAGOPT | grep -c '"ID": "'$1'"'


### PR DESCRIPTION
@zbizaca This change allows us to tag services by cluster or facet and then wait for tagged services to be present
